### PR TITLE
POC fixing gradients in Safari

### DIFF
--- a/lib/plugins/backgroundGradient.js
+++ b/lib/plugins/backgroundGradient.js
@@ -24,9 +24,11 @@ export default function(variants) {
       (result, colorValue, colorName) => {
         result[`.bg-gradient-from-${colorName}`] = {
           '--gradient-from': colorValue,
+          '--gradient-to': 'transparent', // this should turn `rgb(x,x,x)` into `rgba(x,x,x,0)`, but idk what to assume about the colors
         };
         result[`.bg-gradient-to-${colorName}`] = {
           '--gradient-to': colorValue,
+          '--gradient-from': 'transparent', // this should turn `rgb(x,x,x)` into `rgba(x,x,x,0)`, but idk what to assume about the colors
         };
       },
       newClasses


### PR DESCRIPTION
So this isn't really a poc, but I'm not sure if `rgbColors` can be used here to extract the color, since the colorValue could be e.g. hsl as well.

see https://ambientimpact.com/web/snippets/safari-bug-with-gradients-that-fade-to-transparent